### PR TITLE
Fix workflow duplicate check

### DIFF
--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -31,7 +31,7 @@ runs:
       with:
         cancel_others: 'true'
         skip_after_successful_duplicate: 'true'
-        concurrent_skipping: 'same_content'
+        concurrent_skipping: 'same_content_newer'
 
     - name: Skip any duplicate running actions if necessary
       shell: bash

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -71,6 +71,10 @@ runs:
       if: ${{ (inputs.non-impact-code) && (steps.non-impact-changed-files.outputs.any_changed == 'true') && (steps.impact-changed-files.outputs.any_changed == 'false') }}
       shell: bash
       run: |
-          echo "This workflow/job should be skipped due to the following reason:"
-          echo "skip_non_impact_code_changes"
           echo "skippable=true" >> $GITHUB_ENV
+
+    - name: Log non-impact code status to summary
+      shell: bash
+      run: |
+        echo "## Non-impact Code Status" >> $GITHUB_STEP_SUMMARY
+        echo "Are code changes non-impact: ${{ env.skippable }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -37,10 +37,6 @@ runs:
       shell: bash
       run: |
         if [ ${{ steps.skip-duplicates.outputs.should_skip }} == 'true' ]; then
-          echo "This workflow/job should be skipped due to the following reason:"
-          echo "${{steps.skip-duplicates.outputs.reason }}"
-          # Skippable should be string format due to truthy expressions
-          # See https://github.com/actions/runner/issues/1173
           echo "skippable=true" >> $GITHUB_ENV
         fi
         

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Run pre criteria assessment
         uses: ./.github/actions/pre-criteria-assessment
-        id: pre-criteria-assessment
 
       - name: Assign pre criteria assessment status
+        id: pre-criteria-assessment
         run: echo "skippable=${{ env.skippable }}" >> $GITHUB_OUTPUT
 
   # This workflow contains a single job called "build"


### PR DESCRIPTION
In the previous PR,  builds were not actually skipping when it needed to, especially under duplicate PR and Push builds.
Additionally, the action will perform a step summary for non impact code changes, and removed some not needed echo logging statements. 