### PR TITLE
Expand non-impact code status logging job summary

### DIFF
--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
       run: |
         echo "## Non-impact Code Status" >> $GITHUB_STEP_SUMMARY
-        echo "Are code changes non-impact: **${{ env.skippable }}**" >> $GITHUB_STEP_SUMMARY
+        echo "Are code changes non-impact: *${{ env.skippable }}*" >> $GITHUB_STEP_SUMMARY
         echo "### Impact code changes: *${{ steps.impact-changed-files.outputs.all_changed_and_modified_files_count }}* files" >> $GITHUB_STEP_SUMMARY
         for file in ${{ steps.impact-changed-files.outputs.all_changed_and_modified_files }}; do
             echo "$file" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -73,4 +73,13 @@ runs:
       shell: bash
       run: |
         echo "## Non-impact Code Status" >> $GITHUB_STEP_SUMMARY
-        echo "Are code changes non-impact: ${{ env.skippable }}" >> $GITHUB_STEP_SUMMARY
+        echo "Are code changes non-impact: **${{ env.skippable }}**" >> $GITHUB_STEP_SUMMARY
+        echo "### Impact code changes: *${{ steps.impact-changed-files.outputs.all_changed_and_modified_files_count }}* files" >> $GITHUB_STEP_SUMMARY
+        for file in ${{ steps.impact-changed-files.outputs.all_changed_and_modified_files }}; do
+            echo "$file" >> $GITHUB_STEP_SUMMARY
+        done
+        echo "### Non-impact code changes: *${{ steps.non-impact-changed-files.outputs.all_changed_and_modified_files_count }}* files" >> $GITHUB_STEP_SUMMARY
+        for file in ${{ steps.non-impact-changed-files.outputs.all_changed_and_modified_files }}; do
+            echo "$file" >> $GITHUB_STEP_SUMMARY
+        done
+        


### PR DESCRIPTION
In the future case where the action responsible for detecting non-impact code vs impactful code(to the build) becomes haywire, having the action log exactly what is impactful and what is not impactful will be helpful in debuging situations. 