### PR TITLE
Refactor non impact code

### DIFF
--- a/.github/actions/non-impact-code/action.yml
+++ b/.github/actions/non-impact-code/action.yml
@@ -7,7 +7,7 @@ inputs:
 outputs:
   impactful:
     description: "Whether the code changes affect the build"
-    value: "${{ steps.compare-code.outputs.impactful }}"
+    value: ${{ steps.compare-code.outputs.impactful }}
 
 
 runs:

--- a/.github/actions/non-impact-code/action.yml
+++ b/.github/actions/non-impact-code/action.yml
@@ -1,0 +1,49 @@
+name: 'non-impact-code'
+description: 'Check to see if code changes are impactful'
+inputs:
+    non-impact-files:  
+      description: 'A file or list of files marked as non-impact'
+      required: true
+outputs:
+  impactful:
+    description: "Whether the code changes affect the build"
+    value: "${{ steps.compare-code.outputs.impactful }}"
+
+
+runs:
+  using: "composite"
+  steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get all non-impact changed files
+        id: non-impact-changed-files
+        uses: tj-actions/changed-files@v40
+        with:
+          files: ${{ inputs.non-impact-files }}
+      
+      - name: Get all impact changing files
+        id: impact-changed-files
+        uses: tj-actions/changed-files@v40
+        with:
+          files_ignore: ${{ inputs.non-impact-files }}
+        
+      - name: Check non-impact-code
+        id: compare-code
+        shell: bash
+        run: echo "impactful=${{ (steps.non-impact-changed-files.outputs.any_changed == 'true') && (steps.impact-changed-files.outputs.any_changed == 'false') }}" >> $GITHUB_OUTPUT
+
+      - name: Log non-impact code status to summary
+        shell: bash
+        run: |
+          echo "## Non-impact Code Status" >> $GITHUB_STEP_SUMMARY
+          echo "Are code changes non-impact: *${{ steps.compare-code.outputs.impactful }}*" >> $GITHUB_STEP_SUMMARY
+          echo "### Impact code changes: *${{ steps.impact-changed-files.outputs.all_changed_and_modified_files_count }}* files" >> $GITHUB_STEP_SUMMARY
+          for file in ${{ steps.impact-changed-files.outputs.all_changed_and_modified_files }}; do
+              echo "$file" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "### Non-impact code changes: *${{ steps.non-impact-changed-files.outputs.all_changed_and_modified_files_count }}* files" >> $GITHUB_STEP_SUMMARY
+          for file in ${{ steps.non-impact-changed-files.outputs.all_changed_and_modified_files }}; do
+              echo "$file" >> $GITHUB_STEP_SUMMARY
+          done

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -49,5 +49,5 @@ runs:
     - name: Log pre-criteria-assessment summary
       shell: bash
       run: |
-        echo "## Assessment Results" >> $GITHUB_STEP_SUMMARY
+        echo "## Final Assessment Results" >> $GITHUB_STEP_SUMMARY
         echo "Should the build be skipped: *${{ env.skippable }}*" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -1,5 +1,5 @@
-name: 'pre-criteria-assessment'
-description: 'Automatically passes or fails workflow based off a set of criteria'
+name: "pre-criteria-assessment"
+description: "Automatically passes or fails workflow based off a set of criteria"
 inputs:
   non-impact-code:
     description: "Should the workflow automatically pass workflows or jobs with only non-impact code(like only documentation changes)?"
@@ -16,70 +16,33 @@ outputs:
     description: "Whether or not the pre criteria assessment passes a workflow or job from running"
     value: "${{ env.skippable }}"
 
-
 runs:
   using: "composite"
   steps:
-
-    - name: Set default output variables
-      shell: bash
-      run: echo "skippable=${{ false }}" >> $GITHUB_ENV
+    - name: Run non-impact-code analysis
+      uses: ./.github/actions/non-impact-code
+      id: non-impact-code
+      if: ${{ inputs.non-impact-code }}
+      with:
+        non-impact-files: |
+          docs/**
+          LICENSE
+          README.md
 
     - name: Analyze any duplicate running actions
       uses: fkirc/skip-duplicate-actions@v5
       id: skip-duplicates
+      if: ${{ inputs.skip-duplicates }}
       with:
-        cancel_others: 'true'
-        skip_after_successful_duplicate: 'true'
-        concurrent_skipping: 'same_content_newer'
+        cancel_others: "true"
+        skip_after_successful_duplicate: "true"
+        concurrent_skipping: "same_content_newer"
 
-    - name: Skip any duplicate running actions if necessary
-      shell: bash
+    - name: Assign the pre-criteria-assessment results
+      id: assessment-status
       run: |
-        if [ ${{ steps.skip-duplicates.outputs.should_skip }} == 'true' ]; then
-          echo "skippable=true" >> $GITHUB_ENV
-        fi
-        
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Get all non-impact changed files
-      id: non-impact-changed-files
-      uses: tj-actions/changed-files@v40
-      with:
-        # Todo: Replace the files with a single variable to remove code duplication
-        files: |
-          docs/**
-          LICENSE
-          README.md
-    
-    - name: Get all impact changing files
-      id: impact-changed-files
-      uses: tj-actions/changed-files@v40
-      with:
-        files_ignore: |
-          docs/**
-          LICENSE
-          README.md
-      
-    - name: Check if only non-impacting code has changed and pass as necessary
-      if: ${{ (inputs.non-impact-code) && (steps.non-impact-changed-files.outputs.any_changed == 'true') && (steps.impact-changed-files.outputs.any_changed == 'false') }}
-      shell: bash
-      run: |
-          echo "skippable=true" >> $GITHUB_ENV
-
-    - name: Log non-impact code status to summary
-      shell: bash
-      run: |
-        echo "## Non-impact Code Status" >> $GITHUB_STEP_SUMMARY
-        echo "Are code changes non-impact: *${{ env.skippable }}*" >> $GITHUB_STEP_SUMMARY
-        echo "### Impact code changes: *${{ steps.impact-changed-files.outputs.all_changed_and_modified_files_count }}* files" >> $GITHUB_STEP_SUMMARY
-        for file in ${{ steps.impact-changed-files.outputs.all_changed_and_modified_files }}; do
-            echo "$file" >> $GITHUB_STEP_SUMMARY
-        done
-        echo "### Non-impact code changes: *${{ steps.non-impact-changed-files.outputs.all_changed_and_modified_files_count }}* files" >> $GITHUB_STEP_SUMMARY
-        for file in ${{ steps.non-impact-changed-files.outputs.all_changed_and_modified_files }}; do
-            echo "$file" >> $GITHUB_STEP_SUMMARY
-        done
-        
+        echo "skippable=${{ 
+        ((inputs.non-impact-code) && (steps.non-impact-code.outputs.impactful)) 
+        || 
+        ((inputs.skip-duplicates) && (steps.skip-duplicates.outputs.should_skip)) 
+        }}" >> $GITHUB_ENV

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -45,3 +45,9 @@ runs:
         || 
         ((inputs.skip-duplicates == 'true') && (steps.skip-duplicates.outputs.should_skip)) 
         }}" >> $GITHUB_ENV
+
+    - name: Log pre-criteria-assessment summary
+      shell: bash
+      run: |
+        echo "## Assessment Results" >> $GITHUB_STEP_SUMMARY
+        echo "Should the build be skipped: *${{ env.skippable }}*" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -17,6 +17,15 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Analyze any duplicate running actions
+      uses: fkirc/skip-duplicate-actions@v5
+      id: skip-duplicates
+      if: ${{ inputs.skip-duplicates == 'true' }}
+      with:
+        cancel_others: "true"
+        skip_after_successful_duplicate: "true"
+        concurrent_skipping: "same_content_newer"
+
     - name: Run non-impact-code analysis
       uses: ./.github/actions/non-impact-code
       id: non-impact-code
@@ -26,15 +35,6 @@ runs:
           docs/**
           LICENSE
           README.md
-
-    - name: Analyze any duplicate running actions
-      uses: fkirc/skip-duplicate-actions@v5
-      id: skip-duplicates
-      if: ${{ inputs.skip-duplicates == 'true' }}
-      with:
-        cancel_others: "true"
-        skip_after_successful_duplicate: "true"
-        concurrent_skipping: "same_content_newer"
 
     - name: Assign the pre-criteria-assessment results
       id: assessment-status

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -12,7 +12,7 @@ inputs:
 outputs:
   skippable:
     description: "Whether or not the pre criteria assessment passes a workflow or job from running"
-    value: "${{ env.skippable }}"
+    value: ${{ env.skippable }}
 
 runs:
   using: "composite"
@@ -41,9 +41,9 @@ runs:
       shell: bash
       run: |
         echo "skippable=${{ 
-        ((inputs.non-impact-code == 'true') && (steps.non-impact-code.outputs.impactful)) 
+        ((inputs.non-impact-code == 'true') && (steps.non-impact-code.outputs.impactful == 'true')) 
         || 
-        ((inputs.skip-duplicates == 'true') && (steps.skip-duplicates.outputs.should_skip)) 
+        ((inputs.skip-duplicates == 'true') && (steps.skip-duplicates.outputs.should_skip == 'true')) 
         }}" >> $GITHUB_ENV
 
     - name: Log pre-criteria-assessment summary

--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -3,14 +3,12 @@ description: "Automatically passes or fails workflow based off a set of criteria
 inputs:
   non-impact-code:
     description: "Should the workflow automatically pass workflows or jobs with only non-impact code(like only documentation changes)?"
-    type: boolean
     required: false
-    default: true
+    default: 'true'
   skip-duplicates:
     description: "Should the workflow automatically pass duplicate workflows or jobs?"
-    type: boolean
     required: false
-    default: true
+    default: 'true'
 outputs:
   skippable:
     description: "Whether or not the pre criteria assessment passes a workflow or job from running"
@@ -22,7 +20,7 @@ runs:
     - name: Run non-impact-code analysis
       uses: ./.github/actions/non-impact-code
       id: non-impact-code
-      if: ${{ inputs.non-impact-code }}
+      if: ${{ inputs.non-impact-code == 'true' }}
       with:
         non-impact-files: |
           docs/**
@@ -32,7 +30,7 @@ runs:
     - name: Analyze any duplicate running actions
       uses: fkirc/skip-duplicate-actions@v5
       id: skip-duplicates
-      if: ${{ inputs.skip-duplicates }}
+      if: ${{ inputs.skip-duplicates == 'true' }}
       with:
         cancel_others: "true"
         skip_after_successful_duplicate: "true"
@@ -40,9 +38,10 @@ runs:
 
     - name: Assign the pre-criteria-assessment results
       id: assessment-status
+      shell: bash
       run: |
         echo "skippable=${{ 
-        ((inputs.non-impact-code) && (steps.non-impact-code.outputs.impactful)) 
+        ((inputs.non-impact-code == 'true') && (steps.non-impact-code.outputs.impactful)) 
         || 
-        ((inputs.skip-duplicates) && (steps.skip-duplicates.outputs.should_skip)) 
+        ((inputs.skip-duplicates == 'true') && (steps.skip-duplicates.outputs.should_skip)) 
         }}" >> $GITHUB_ENV

--- a/.github/workflows/automatic-build-livecd.yml
+++ b/.github/workflows/automatic-build-livecd.yml
@@ -36,7 +36,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        formats: [install-iso, proxmox-lxc]
+        formats: [proxmox-lxc]
     uses: ./.github/workflows/build-livecd.yml
     with:
       configuration: configuration.nix


### PR DESCRIPTION
Non impact code is now it's own action, with additional logging to show the final results of the pre assessment check. Additionally, install-iso will now longer be automatically built because A) install-iso takes a very long time to build and  B) anyone can trigger any build format they want from the gui