### PR TITLE
build: Remove cloudstack from default options as it is currently 'bro…

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       tag: 
-        description: 'The release version'
+        description: 'The release version/tag'
         type: string
         required: true
       formats:  
         description: "A list of livecd formats to release as an artifact, using ['a', 'b', 'c'] notation"
         type: string
         required: true
-        default: "['install-iso', 'virtualbox', 'vmware', 'proxmox-lxc', 'proxmox', 'linode', 'hyperv', 'gce', 'docker', 'do', 'cloudstack', 'azure', 'amazon']"
+        default: "['install-iso', 'virtualbox', 'vmware', 'proxmox-lxc', 'proxmox', 'linode', 'hyperv', 'gce', 'docker', 'do', 'azure', 'amazon']"
       commitish:
         description: "Passthrough from action-gh-release: 'Commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Defaults to repository default branch.'"
         required: false


### PR DESCRIPTION
…ken'

What was intended to be a refactoring of the release workflow whereby the process of having to upload/redownload the same generated artifact as it passes through each job by having the enviornment be shared turns out to be impossible. (See https://github.com/actions/runner/pull/2477). For now, since 'cloudstack' is broken format(See https://github.com/nix-community/nixos-generators/tree/master/formats-broken) we shall remove that from the default inputs in the workflow dispatch. 