### PR TITLE
build: Creating the draft release step in draft-release will always r…

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -33,6 +33,7 @@ jobs:
       format: ${{ matrix.formats }}
   draft_release:
     needs: build_release
+    if: always()
     runs-on: ubuntu-latest
     env:
       asset-path: ./assets


### PR DESCRIPTION
…un indepedent on build status

Before, failure on one build will affect the failure of another builds. Now, failure on any one build will not stop the draft of the release from being created. 

The releases that are automatically created are always in draft, and serves to help automate some parts of the process. Some human intervention will be needed at some points to review the release and make changes as needed.