### PR TITLE
Only allow certain formats to be built

### DIFF
--- a/.github/workflows/automatic-build-livecd.yml
+++ b/.github/workflows/automatic-build-livecd.yml
@@ -36,7 +36,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        formats: [proxmox-lxc]
+        formats: [install-iso, virtualbox, proxmox-lxc, proxmox, linode, gce, docker, do]
     uses: ./.github/workflows/build-livecd.yml
     with:
       configuration: configuration.nix

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -13,7 +13,7 @@ on:
         description: "A list of livecd formats to release as an artifact, using ['a', 'b', 'c'] notation"
         type: string
         required: true
-        default: "['install-iso', 'virtualbox', 'vmware', 'proxmox-lxc', 'proxmox', 'linode', 'hyperv', 'gce', 'docker', 'do', 'azure', 'amazon']"
+        default: "['install-iso', 'virtualbox', 'proxmox-lxc', 'proxmox', 'linode', 'gce', 'docker', 'do']"
       commitish:
         description: "Passthrough from action-gh-release: 'Commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Defaults to repository default branch.'"
         required: false


### PR DESCRIPTION
The nixos image [builder](https://github.com/nix-community/nixos-generators) allows you to build an nixos image to many different formats. Just for the sake of variety the ci/cd builds these formats whenever it is possible to do so. 

However only certain formats should be built, depending on their default build reliability and size. For example, any formats that failed to build despite having a template configuration will not be allowed as a default build for release. Similarly if the formats already exceed the release asset 2GB size limit despite having a small configuration, then these formats can't be included in our release no matter what.

You can still build these images by running a dispatch workflow under Actions, it's just that these formats will not be supported/built by default for technical reasons. 