### PR TITLE
fix: Allow ssh PermitRootLogin to be overrided by lib.mkDefault

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -12,6 +12,6 @@
   system.stateVersion = lib.version;
 
   users.users.root.password = "nixos";
-  services.openssh.settings.PermitRootLogin = lib.mkDefault "yes";
+  services.openssh.settings.PermitRootLogin = lib.mkForce "yes";
   services.getty.autologinUser = lib.mkDefault "root";
 }


### PR DESCRIPTION
The default template configuration provided by (nixos-generator)[https://github.com/nix-community/nixos-generators] fails because it forces a conflict where its open ssh permitrootlogin setting has two duplicate values but identical priority.

Simple fix where our configuration has lower prorirty allows the build format to override the values when needed.