### PR TITLE
Refactor draft release

### DIFF
--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -84,12 +84,16 @@ jobs:
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           filename=$(basename "${{ env.image-path }}")
           artifact_name=${{ inputs.format }}-${git_hash}-${filename}
-          target=$(dirname "${{ env.image-path }}")/$artifact_name
-          mv "${{ env.image-path }}" "$target"
-          echo "image-path=$target" >> $GITHUB_ENV
+          cd "$(dirname '${{ env.image-path }'}"
+          #Move will require sudo permissions
+          sudo mv "$filename" "$artifact_name"
+          #Preserve nix store directory with hard link
+          ln "$artifact_name" "$filename"
+          echo "asset-path=$(readlink -f '$artifact_name')" >> $GITHUB_OUTPUT
           echo "artifact-name=$artifact_name" >> $GITHUB_ENV
+        id: build-files
 
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.artifact-name }}
-          path: ${{ env.image-path }}
+          path: ${{ steps.build-files.outputs.asset-path }}

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -89,7 +89,7 @@ jobs:
           sudo mv "$filename" "$artifact_name"
           #Preserve nix store directory with hard link
           sudo ln "$artifact_name" "$filename"
-          echo "asset-path=$(readlink -f '$artifact_name')" >> $GITHUB_OUTPUT
+          echo "asset-path=$(readlink -f "${artifact_name}")" >> $GITHUB_OUTPUT
           echo "artifact-name=${artifact_name}" >> $GITHUB_ENV
         id: build-files
 

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -84,7 +84,7 @@ jobs:
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           filename=$(basename "${{ env.image-path }}")
           artifact_name=${{ inputs.format }}-${git_hash}-${filename}
-          cd "$(dirname '${{ env.image-path }'}"
+          cd "$(dirname '${{ env.image-path }}'"
           #Move will require sudo permissions
           sudo mv "$filename" "$artifact_name"
           #Preserve nix store directory with hard link

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -88,7 +88,7 @@ jobs:
           #Move will require sudo permissions
           sudo mv "$filename" "$artifact_name"
           #Preserve nix store directory with hard link
-          ln "$artifact_name" "$filename"
+          sudo ln "$artifact_name" "$filename"
           echo "asset-path=$(readlink -f '$artifact_name')" >> $GITHUB_OUTPUT
           echo "artifact-name=$artifact_name" >> $GITHUB_ENV
         id: build-files

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -84,7 +84,7 @@ jobs:
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           filename=$(basename "${{ env.image-path }}")
           artifact_name=${{ inputs.format }}-${git_hash}-${filename}
-          cd "$(dirname '${{ env.image-path }}'"
+          cd "$(dirname '${{ env.image-path }}')"
           #Move will require sudo permissions
           sudo mv "$filename" "$artifact_name"
           #Preserve nix store directory with hard link

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -82,8 +82,12 @@ jobs:
           # Get short git hash from
           # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
-          filename=$(basename ${{ env.image-path }})
-          echo "artifact-name=${{ inputs.format }}-${git_hash}-${filename}" >> $GITHUB_ENV
+          filename=$(basename "${{ env.image-path }}")
+          artifact_name=${{ inputs.format }}-${git_hash}-${filename}
+          target=$(dirname "${{ env.image-path }}")/$artifact_name
+          mv "${{ env.image-path }}" "$target"
+          echo "image-path=$target" >> $GITHUB_ENV
+          echo "artifact-name=$artifact_name" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -90,7 +90,7 @@ jobs:
           #Preserve nix store directory with hard link
           sudo ln "$artifact_name" "$filename"
           echo "asset-path=$(readlink -f '$artifact_name')" >> $GITHUB_OUTPUT
-          echo "artifact-name=$artifact_name" >> $GITHUB_ENV
+          echo "artifact-name=${artifact_name}" >> $GITHUB_ENV
         id: build-files
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Draft release workflow had problems where it could not handle duplicate files. 
Upon further inspection, the problem lied within build-livecd as the filename itself was not following the artifact name. 
Because of that refactor-draft-release ended up pushing fixes to build-livecd. 