### PR TITLE
Fix draft release commitish

### DIFF
--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -92,9 +92,9 @@ jobs:
           artifact_name=${{ inputs.format }}-${git_hash}-${filename}
           cd "$(dirname '${{ env.image-path }}')"
           #Move will require sudo permissions
-          sudo mv "$filename" "$artifact_name"
+          sudo mv -v "$filename" "$artifact_name"
           #Preserve nix store directory with hard link
-          sudo ln "$artifact_name" "$filename"
+          sudo ln -v "$artifact_name" "$filename"
           echo "asset-path=$(readlink -f "${artifact_name}")" >> $GITHUB_OUTPUT
           echo "artifact-name=${artifact_name}" >> $GITHUB_ENV
         id: build-files

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Get short git hash from
           # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action
-          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          git_hash=$(git rev-parse --short HEAD)
           filename=$(basename "${{ env.image-path }}")
           artifact_name=${{ inputs.format }}-${git_hash}-${filename}
           cd "$(dirname '${{ env.image-path }}')"

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
         default: 'install-iso'
+      commitish:
+        description: "Manually override which commmit/branch the build should be based on. Passthrough from action-gh-release: 'Commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Defaults to repository default branch.'"
+        type: string
+        required: false
 
   workflow_dispatch:
     # TODO: Once input duplication is not needed anymore, refactor the input duplicate code.
@@ -69,6 +73,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commitish }}
 
       - name: Generate NixOS Image
         uses: ./.github/actions/generate-nixos-image

--- a/.github/workflows/debug-draft-release.yml
+++ b/.github/workflows/debug-draft-release.yml
@@ -55,12 +55,12 @@ jobs:
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          tag_name=${{ inputs.tag }}
           echo $git_hash
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=${filename/$git_hash/$tag_name}
+              release=$(echo "$filename" | sed -e "s/$git_hash/${{ inputs.tag }}/g")
+              test_version=$(echo ${{ steps.tag_version.outputs.new_version }} |  sed 's/[^0-9,a-z,A-Z]/\-/g')
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,7 @@ jobs:
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=${filename/$git_hash/${{ inputs.tag }}}
+              release="${filename/$git_hash/${{ inputs.tag }}}"
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -39,12 +39,21 @@ jobs:
       asset-path: ./assets
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commitish }}
 
       - name: Retrieve the build files
         uses: actions/download-artifact@v3
         id: build-files
         with:
           path: ${{ env.asset-path }}
+
+      - name: Assign asset filenames
+        run: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          for file in ${{ env.asset-path }}; do
+            mv -v "$file" "${file/$git_hash/${{ inputs.tag }}}"
+          done
 
       - name: Create the release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -52,14 +52,17 @@ jobs:
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          for file in ${{ env.asset-path }}/*; do
-            mv -v "$file" "${file/$git_hash/${{ inputs.tag }}}"
+          cd "${{ steps.build-files.outputs.asset-path }}"
+          for file in "${{ steps.build-files.outputs.asset-path }}"/*; do
+            filename=$(basename "$file")
+            release=${file/$git_hash/${{ inputs.tag }}}
+            mv -v "$filename" "$release"
           done
 
       - name: Create the release
         uses: softprops/action-gh-release@v1
         with: 
-          files: ${{ env.asset-path }}/**
+          files: ${{ steps.build-files.outputs.asset-path }}/**
           tag_name: ${{ inputs.tag }}
           draft: true
           target_commitish: ${{ inputs.commitish }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           path: ${{ env.asset-path }}
 
+      - name: List directory
+        run: ls -R "${{ steps.build-files.outputs.download-path }}"
+
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          cd "${{ steps.build-files.outputs.asset-path }}"
+          cd "${{ steps.build-files.outputs.download-path }}"
           for file in "${{ steps.build-files.outputs.asset-path }}"/*; do
             filename=$(basename "$file")
             release=${file/$git_hash/${{ inputs.tag }}}
@@ -62,7 +62,7 @@ jobs:
       - name: Create the release
         uses: softprops/action-gh-release@v1
         with: 
-          files: ${{ steps.build-files.outputs.asset-path }}/**
+          files: ${{ steps.build-files.outputs.download-path }}/**
           tag_name: ${{ inputs.tag }}
           draft: true
           target_commitish: ${{ inputs.commitish }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,7 @@ jobs:
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=$(echo "${filename}" | sed "s/\$git_hash/${{ inputs.tag }}/")
+              release=$(echo "$filename" | sed "s/$git_hash/${{ inputs.tag }}/")
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          for file in ${{ env.asset-path }}; do
+          for file in ${{ env.asset-path }}/*; do
             mv -v "$file" "${file/$git_hash/${{ inputs.tag }}}"
           done
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           git_hash=$(git rev-parse --short HEAD)
           cd "${{ steps.build-files.outputs.download-path }}"
-          find "${{ steps.build-files.outputs.download-path }}" -mindepth 1 -exec bash -c '
+          find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               filename=$(basename "$0")
               release=${filename/$git_hash/${{ inputs.tag }}}
               mv -v "$filename" "$release"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,7 +9,6 @@ on:
         description: 'The release version/tag'
         type: string
         required: true
-        default: 'default'
       formats:  
         description: "A list of livecd formats to release as an artifact, using ['a', 'b', 'c'] notation"
         type: string

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,7 @@ jobs:
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release="${filename/$git_hash/${{ inputs.tag }}}"
+              release=$(echo "${filename}" | sed "s/\$git_hash/${{ inputs.tag }}/")
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -55,9 +55,12 @@ jobs:
           cd "${{ steps.build-files.outputs.download-path }}"
           for file in "${{ steps.build-files.outputs.download-path }}"/*; do
             filename=$(basename "$file")
-            release=${file/$git_hash/${{ inputs.tag }}}
+            release=${filename/$git_hash/${{ inputs.tag }}}
             mv -v "$filename" "$release"
           done
+
+      - name: List directory
+        run: ls -R "${{ steps.build-files.outputs.download-path }}"
 
       - name: Create the release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,7 @@ jobs:
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=$(echo "$filename" | sed "s/$git_hash/${{ inputs.tag }}/")
+              release=$(echo "$filename" | sed -e "s/$git_hash/${{ inputs.tag }}/g")
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -53,11 +53,11 @@ jobs:
         run: |
           git_hash=$(git rev-parse --short HEAD)
           cd "${{ steps.build-files.outputs.download-path }}"
-          for file in "${{ steps.build-files.outputs.download-path }}"/*; do
-            filename=$(basename "$file")
-            release=${filename/$git_hash/${{ inputs.tag }}}
-            mv -v "$filename" "$release"
-          done
+          find ${{ steps.build-files.outputs.download-path }} -exec bash -c '
+              filename=$(basename "$0")
+              release=${filename/$git_hash/${{ inputs.tag }}}
+              mv -v "$filename" "$release"
+          ' {} \;
 
       - name: List directory
         run: ls -R "${{ steps.build-files.outputs.download-path }}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -39,6 +39,9 @@ jobs:
     env:
       asset-path: ./assets
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commitish }}
 
       - name: Retrieve the build files
         uses: actions/download-artifact@v3
@@ -48,7 +51,7 @@ jobs:
 
       - name: Assign asset filenames
         run: |
-          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          git_hash=$(git rev-parse --short HEAD)
           for file in ${{ env.asset-path }}; do
             mv -v "$file" "${file/$git_hash/${{ inputs.tag }}}"
           done

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -55,12 +55,11 @@ jobs:
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          tag_name=${{ inputs.tag }}
           echo $git_hash
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=${filename/$git_hash/$tag_name}
+              release=$(echo "$filename" | sed -e "s/$git_hash/input/g")
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,7 @@ jobs:
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=$(echo "$filename" | awk "{gsub(/$git_hash/, \"${{ inputs.tag }}\"); print}")
+              release=$(echo "$filename" | awk -v git_hash="$git_hash" "{gsub(git_hash, \"${{ inputs.tag }}\"); print}")
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           git_hash=$(git rev-parse --short HEAD)
           cd "${{ steps.build-files.outputs.download-path }}"
-          find ${{ steps.build-files.outputs.download-path }} -exec bash -c '
+          find "${{ steps.build-files.outputs.download-path }}" -exec bash -c '
               filename=$(basename "$0")
               release=${filename/$git_hash/${{ inputs.tag }}}
               mv -v "$filename" "$release"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -52,6 +52,9 @@ jobs:
       - name: List directory
         run: ls -R "${{ steps.build-files.outputs.download-path }}"
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
@@ -59,7 +62,7 @@ jobs:
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=$(echo "$filename" | awk -v git_hash="$git_hash" "{gsub(git_hash, \"${{ inputs.tag }}\"); print}")
+              release=$(echo "$filename" | awk -v git_hash="$git_hash" "{gsub(git_hash, "${{ inputs.tag }}"); print}")
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           git_hash=$(git rev-parse --short HEAD)
           cd "${{ steps.build-files.outputs.download-path }}"
-          find "${{ steps.build-files.outputs.download-path }}" -exec bash -c '
+          find "${{ steps.build-files.outputs.download-path }}" -mindepth 1 -exec bash -c '
               filename=$(basename "$0")
               release=${filename/$git_hash/${{ inputs.tag }}}
               mv -v "$filename" "$release"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,7 @@ jobs:
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
-              release=$(echo "$filename" | sed -e "s/$git_hash/input/g")
+              release=$(echo "$filename" | awk "{gsub(/$git_hash/, \"${{ inputs.tag }}\"); print}")
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -55,11 +55,11 @@ jobs:
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          cd "${{ steps.build-files.outputs.download-path }}"
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
+              asset_dir=$(dirname "$0")
               filename=$(basename "$0")
               release=${filename/$git_hash/${{ inputs.tag }}}
-              mv -v "$filename" "$release"
+              mv -v "$asset-dir/$filename" "$asset_dir/$release"
           ' {} \;
 
       - name: List directory

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
+          echo $git_hash
           find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,6 +9,7 @@ on:
         description: 'The release version/tag'
         type: string
         required: true
+        default: 'default'
       formats:  
         description: "A list of livecd formats to release as an artifact, using ['a', 'b', 'c'] notation"
         type: string
@@ -31,6 +32,7 @@ jobs:
     with:
       configuration: configuration.nix
       format: ${{ matrix.formats }}
+      commitish: ${{ inputs.commitish }}
   draft_release:
     needs: build_release
     if: always()
@@ -38,9 +40,6 @@ jobs:
     env:
       asset-path: ./assets
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.commitish }}
 
       - name: Retrieve the build files
         uses: actions/download-artifact@v3

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           git_hash=$(git rev-parse --short HEAD)
           cd "${{ steps.build-files.outputs.download-path }}"
-          for file in "${{ steps.build-files.outputs.asset-path }}"/*; do
+          for file in "${{ steps.build-files.outputs.download-path }}"/*; do
             filename=$(basename "$file")
             release=${file/$git_hash/${{ inputs.tag }}}
             mv -v "$filename" "$release"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -52,19 +52,16 @@ jobs:
       - name: List directory
         run: ls -R "${{ steps.build-files.outputs.download-path }}"
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-
       - name: Assign asset filenames
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          echo $git_hash
-          find "${{ steps.build-files.outputs.download-path }}" -type f -exec bash -c '
-              asset_dir=$(dirname "$0")
-              filename=$(basename "$0")
-              release=$(echo "$filename" | awk -v git_hash="$git_hash" "{gsub(git_hash, "${{ inputs.tag }}"); print}")
+          find "${{ steps.build-files.outputs.download-path }}" -type f -print0 | 
+            while IFS= read -r -d '' path; do 
+              asset_dir=$(dirname "$path")
+              filename=$(basename "$path")
+              release=${filename/$git_hash/"test"}
               mv -v "$asset_dir/$filename" "$asset_dir/$release"
-          ' {} \;
+          done
 
       - name: List directory
         run: ls -R "${{ steps.build-files.outputs.download-path }}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,7 @@ jobs:
               asset_dir=$(dirname "$0")
               filename=$(basename "$0")
               release=${filename/$git_hash/${{ inputs.tag }}}
-              mv -v "$asset-dir/$filename" "$asset_dir/$release"
+              mv -v "$asset_dir/$filename" "$asset_dir/$release"
           ' {} \;
 
       - name: List directory


### PR DESCRIPTION
Current draft release did not properly let the builds be based off the actual commits specified in the workflow dispatch, and instead defaulting to the latest commit.

Additionally for draft release the artifact github sha's are replaced by the tags. 