### PR TITLE
Add support for commitish builds and draft-release names

### DIFF
--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -92,9 +92,9 @@ jobs:
           artifact_name=${{ inputs.format }}-${git_hash}-${filename}
           cd "$(dirname '${{ env.image-path }}')"
           #Move will require sudo permissions
-          sudo mv "$filename" "$artifact_name"
+          sudo mv -v "$filename" "$artifact_name"
           #Preserve nix store directory with hard link
-          sudo ln "$artifact_name" "$filename"
+          sudo ln -v "$artifact_name" "$filename"
           echo "asset-path=$(readlink -f "${artifact_name}")" >> $GITHUB_OUTPUT
           echo "artifact-name=${artifact_name}" >> $GITHUB_ENV
         id: build-files

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
         default: 'install-iso'
+      commitish:
+        description: "Manually override which commmit/branch the build should be based on. Passthrough from action-gh-release: 'Commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Defaults to repository default branch.'"
+        type: string
+        required: false
 
   workflow_dispatch:
     # TODO: Once input duplication is not needed anymore, refactor the input duplicate code.
@@ -69,6 +73,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commitish }}
 
       - name: Generate NixOS Image
         uses: ./.github/actions/generate-nixos-image
@@ -81,7 +87,7 @@ jobs:
         run: |
           # Get short git hash from
           # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action
-          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          git_hash=$(git rev-parse --short HEAD)
           filename=$(basename "${{ env.image-path }}")
           artifact_name=${{ inputs.format }}-${git_hash}-${filename}
           cd "$(dirname '${{ env.image-path }}')"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -31,6 +31,7 @@ jobs:
     with:
       configuration: configuration.nix
       format: ${{ matrix.formats }}
+      commitish: ${{ inputs.commitish }}
   draft_release:
     needs: build_release
     if: always()
@@ -39,6 +40,8 @@ jobs:
       asset-path: ./assets
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commitish }}
 
       - name: Retrieve the build files
         uses: actions/download-artifact@v3

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -49,6 +49,17 @@ jobs:
         with:
           path: ${{ env.asset-path }}
 
+      - name: Assign asset filenames
+        run: |
+          git_hash=$(git rev-parse --short HEAD)
+          find "${{ steps.build-files.outputs.download-path }}" -type f -print0 | 
+            while IFS= read -r -d '' path; do 
+              asset_dir=$(dirname "$path")
+              filename=$(basename "$path")
+              release=${filename/$git_hash/"${{ inputs.tag }}"}
+              mv "$asset_dir/$filename" "$asset_dir/$release"
+          done
+
       - name: Create the release
         uses: softprops/action-gh-release@v1
         with: 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Create the release
         uses: softprops/action-gh-release@v1
         with: 
-          files: ${{ env.asset-path }}/**
+          files: ${{ steps.build-files.outputs.download-path }}/**
           tag_name: ${{ inputs.tag }}
           draft: true
           target_commitish: ${{ inputs.commitish }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -57,7 +57,7 @@ jobs:
               asset_dir=$(dirname "$path")
               filename=$(basename "$path")
               release=${filename/$git_hash/"${{ inputs.tag }}"}
-              mv "$asset_dir/$filename" "$asset_dir/$release"
+              mv -v "$asset_dir/$filename" "$asset_dir/$release"
           done
 
       - name: Create the release


### PR DESCRIPTION
This PR enables build-live and draft-release to base any build off an existing commit.

Secondly, the previous implementation meant that the release names still have the following commit SHA's attached to each filename, which may have been useful for tracing artifacts but not so useful for release assets. Now the release asset will have the corresponding tag in the filename instead of the SHA.