### PR TITLE
Add PR template and skips builds that modify PR/ISSUE templates

### DIFF
--- a/.github/actions/pre-criteria-assessment/action.yml
+++ b/.github/actions/pre-criteria-assessment/action.yml
@@ -35,6 +35,9 @@ runs:
           docs/**
           LICENSE
           README.md
+          .github/pull_request_template.md
+          .github/ISSUE_TEMPLATE/**.yml
+          .github/ISSUE_TEMPLATE/**.md
 
     - name: Assign the pre-criteria-assessment results
       id: assessment-status

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+# Pull Request Name
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation change (non-impact change which absolutely does not alter build output)
+- [ ] This change requires a documentation update
+
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have checked my code and corrected any misspellings
+
+## How Has This Been Tested?
+
+If the changes are for an complex functional module that does not mainly depend on already tested upstream code, then  
+please describe the tests that you ran to verify your changes with reproducible instructions, and any other relevant details for test configuration. Otherwise, please remove this section entirely. 
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+* NixOS version:
+* Nixpkg version:
+* Testbed:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-# Pull Request Name
-
 ## Description
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
@@ -36,5 +34,4 @@ please describe the tests that you ran to verify your changes with reproducible 
 
 **Test Configuration**:
 * NixOS version:
-* Nixpkg version:
 * Testbed:


### PR DESCRIPTION
## Description

Adds an PR template for ease of use. Additionally, the pre-criteria-assessment will now ignore any PR and ISSUE templates as they do not impact the build.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change (non-impact change which absolutely does not alter build output)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
