### PR TITLE
Switch build process to use flakes

### DIFF
--- a/.github/actions/generate-nixos-image/action.yml
+++ b/.github/actions/generate-nixos-image/action.yml
@@ -2,7 +2,7 @@ name: 'generate-nixos-image'
 description: 'Builds a nixOS image'
 inputs:
   flake:
-    description: 'The path of the flake uri describing the nix configuration like "~/dotfiles#my-config"'
+    description: 'The path of the flake uri describing the nix configuration like "./#nixos-livecd"'
     required: false
   configuration:  
     description: 'The path or filename of the nix configuration describing the image. If a flake input is supplied, then this input is ignored'

--- a/.github/actions/generate-nixos-image/action.yml
+++ b/.github/actions/generate-nixos-image/action.yml
@@ -75,9 +75,9 @@ runs:
         # Github Inputs are inaccessible for nested composite actions, use github_env as a workaround instead
         # See https://github.com/actions/runner/issues/2009
         if [[ -z "${{inputs.flake}}" ]]; then
-          image_path=$(nixos-generate -f ${{ inputs.format }} --flake "${{ inputs.flake }}")
-        else
           image_path=$(nixos-generate -f ${{ inputs.format }} -c ${{ inputs.configuration }})
+        else
+          image_path=$(nixos-generate -f ${{ inputs.format }} --flake "${{ inputs.flake }}")
         fi
         echo "image-path=$image_path" >> $GITHUB_ENV
       shell: bash    

--- a/.github/actions/generate-nixos-image/action.yml
+++ b/.github/actions/generate-nixos-image/action.yml
@@ -1,9 +1,12 @@
 name: 'generate-nixos-image'
 description: 'Builds a nixOS image'
 inputs:
+  flake:
+    description: 'The path of the flake uri describing the nix configuration like "~/dotfiles#my-config"'
+    required: false
   configuration:  
-    description: 'The path or filename of the nix configuration describing the image'
-    required: true
+    description: 'The path or filename of the nix configuration describing the image. If a flake input is supplied, then this input is ignored'
+    required: false
     default: 'configuration.nix'
   format:
     description: 'The nixOS image format'
@@ -71,6 +74,11 @@ runs:
         echo "Generating the nixOS image..." 
         # Github Inputs are inaccessible for nested composite actions, use github_env as a workaround instead
         # See https://github.com/actions/runner/issues/2009
-        echo "image-path=$(nixos-generate -f ${{ inputs.format }} -c ${{ inputs.configuration }})" >> $GITHUB_ENV
+        if [[ -z "${{inputs.flake}}" ]]; then
+          image_path=$(nixos-generate -f ${{ inputs.format }} --flake "${{ inputs.flake }}")
+        else
+          image_path=$(nixos-generate -f ${{ inputs.format }} -c ${{ inputs.configuration }})
+        fi
+        echo "image-path=$image_path" >> $GITHUB_ENV
       shell: bash    
 

--- a/.github/workflows/automatic-build-livecd.yml
+++ b/.github/workflows/automatic-build-livecd.yml
@@ -39,6 +39,6 @@ jobs:
         formats: [install-iso, virtualbox, proxmox-lxc, proxmox, linode, gce, docker, do]
     uses: ./.github/workflows/build-livecd.yml
     with:
-      configuration: configuration.nix
+      flake: ./#nixos-livecd
       format: ${{ matrix.formats }}
 

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -4,13 +4,13 @@ on:
   workflow_call:
     inputs:
       flake:
-        description: 'The path of the flake uri describing the nix configuration like "~/dotfiles#my-config"'
+        description: 'The path of the flake uri describing the nix configuration like "./#nixos-livecd"'
         type: string
         required: false
       configuration:  
         description: 'The path or filename of the nix configuration describing the image'
         type: string
-        required: true
+        required: false
         default: 'configuration.nix'
       format:
         description: 'The nixOS image format'

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -1,4 +1,4 @@
-run-name: Build a ${{ inputs.format }} livecd with ${{ inputs.configuration }}
+run-name: Build a ${{ inputs.format }} livecd with ${{ inputs.configuration || inputs.flake }}
 
 on:
   workflow_call:

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -3,6 +3,10 @@ run-name: Build a ${{ inputs.format }} livecd with ${{ inputs.configuration }}
 on:
   workflow_call:
     inputs:
+      flake:
+        description: 'The path of the flake uri describing the nix configuration like "~/dotfiles#my-config"'
+        type: string
+        required: false
       configuration:  
         description: 'The path or filename of the nix configuration describing the image'
         type: string
@@ -22,6 +26,10 @@ on:
     # TODO: Once input duplication is not needed anymore, refactor the input duplicate code.
     # See https://github.com/orgs/community/discussions/39357
     inputs:
+      flake:
+        description: 'The path of the flake uri describing the nix configuration like "~/dotfiles#my-config"'
+        type: string
+        required: false
       configuration:  
         description: 'The path or filename of the nix configuration describing the image'
         type: string
@@ -79,6 +87,7 @@ jobs:
       - name: Generate NixOS Image
         uses: ./.github/actions/generate-nixos-image
         with:
+          flake: ${{ inputs.flake }}
           configuration: ${{ inputs.configuration }}
           format: ${{ inputs.format  }}
         id: generate-image

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -11,7 +11,6 @@ on:
         description: 'The path or filename of the nix configuration describing the image'
         type: string
         required: false
-        default: 'configuration.nix'
       format:
         description: 'The nixOS image format'
         required: true
@@ -34,7 +33,6 @@ on:
         description: 'The path or filename of the nix configuration describing the image'
         type: string
         required: true
-        default: 'configuration.nix'
       format:
         description: 'The nixOS image format'
         required: true

--- a/configuration.nix
+++ b/configuration.nix
@@ -4,6 +4,7 @@
   pkgs,
   ...
 }: {
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
   services.sshd.enable = true;
   services.nginx.enable = true;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+# /etc/nixos/flake.nix
+{
+  description = "Dependency management for configuration.nix";
+
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixos-23.11";
+    };
+  };
+
+  outputs = { self, nixpkgs }: {
+    nixosConfigurations = {
+      nixos-livecd = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./configuration.nix
+        ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Description

Adds flake support for building nixOS livecds without having to remove existing functionality on our build processes. Specifically, this current configuration  uses the standard nixOSconfiguration flake templates whereby all of its dependency management code is strictly located in flake.nix, seperating the dependency roles and configuration roles apart.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

