### PR TITLE
Fix virtualbox build disk space

### DIFF
--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -78,6 +78,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # Hacky action that increases extra disk space for format builds that need it
+      # Can break at any time because it is highly dependent on github action's current virtual runner configuration
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        if: inputs.format == 'virtualbox' # Currently only virtualbox needs more build space
+        with:
+          remove-android: 'true'
+          remove-docker-images: 'true'
+          remove-dotnet: 'true'
+
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commitish }}

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -7,6 +7,7 @@ on:
         description: 'The path of the flake uri describing the nix configuration like "./#nixos-livecd"'
         type: string
         required: false
+        default: './#nixos-livecd'
       configuration:  
         description: 'The path or filename of the nix configuration describing the image'
         type: string
@@ -29,10 +30,11 @@ on:
         description: 'The path of the flake uri describing the nix configuration like "~/dotfiles#my-config"'
         type: string
         required: false
+        default: './#nixos-livecd'
       configuration:  
         description: 'The path or filename of the nix configuration describing the image'
         type: string
-        required: true
+        required: false
       format:
         description: 'The nixOS image format'
         required: true

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -80,11 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Hacky action that increases extra disk space for format builds that need it
-      # Can break at any time because it is highly dependent on github action's current virtual runner configuration
+      # Frees available build disk space by removing unnecessary components
+      # Hacky workaround can break at any time dependent on Github's current VM runner configuration
+      # This action slows the build process in exchange for more space, so only use this for formats that really need the extra space
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
-        if: inputs.format == 'virtualbox' # Currently only virtualbox needs more build space
+        if: inputs.format == 'virtualbox'
         with:
           root-reserve-mb: 2048
           remove-android: 'true'

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -84,6 +84,7 @@ jobs:
         uses: easimon/maximize-build-space@master
         if: inputs.format == 'virtualbox' # Currently only virtualbox needs more build space
         with:
+          root-reserve-mb: 2048
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -82,14 +82,11 @@ jobs:
 
       # Frees available build disk space by removing unnecessary components
       # Hacky workaround can break at any time dependent on Github's current VM runner configuration
-      # This action slows the build process in exchange for more space, so only use this for formats that really need the extra space
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: AdityaGarg8/remove-unwanted-software@v1
         if: inputs.format == 'virtualbox'
         with:
-          root-reserve-mb: 2048
           remove-android: 'true'
-          remove-docker-images: 'true'
           remove-dotnet: 'true'
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Adds workarounds to the virtualbox livecd build process, specifically freeing up and moving space to the runner allowing more build disk space.

Additionally, some refactoring on the build-livecd input parameters. They should have a default flake input and configuration.nix is no longer strictly required. 

Fixes #26.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings

