### PR TITLE
revert: Remove docker from automatic build pipeline

### DIFF
--- a/.github/workflows/automatic-build-livecd.yml
+++ b/.github/workflows/automatic-build-livecd.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        formats: [install-iso, virtualbox, proxmox-lxc, proxmox, linode, gce, docker, do]
+        formats: [install-iso, virtualbox, proxmox-lxc, proxmox, linode, gce, do]
     uses: ./.github/workflows/build-livecd.yml
     with:
       flake: ./#nixos-livecd


### PR DESCRIPTION
## Description

Docker builds will fail due to an enviornment xLibs being recompiled. Considering that docker is not typically used to run liveCDs or GUI applications, an solution can be done as to simply not support docker builds.

Fixes #26.

## Type of change

Design desicion change


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
