### PR TITLE
Fix docker build decouple

### DIFF
--- a/modules/patches.nix
+++ b/modules/patches.nix
@@ -3,5 +3,5 @@
 {
     # Fixes missing cairo-lib dependency for docker builds only
     # See https://github.com/NixOS/nixpkgs/issues/119841
-    environment.noXlibs = lib.mkIf boot.isContainer lib.mkForce false;
+    environment.noXlibs = lib.mkIf boot.isContainer (lib.mkForce false);
 }

--- a/modules/patches.nix
+++ b/modules/patches.nix
@@ -1,0 +1,7 @@
+# Technical hotfixes not belonging to any specific livecd feature/requirement 
+{ lib, ... }:
+{
+    # Fixes missing cairo-lib dependency for docker builds only
+    # See https://github.com/NixOS/nixpkgs/issues/119841
+    environment.noXlibs = lib.mkIf boot.isContainer lib.mkForce false;
+}

--- a/modules/patches.nix
+++ b/modules/patches.nix
@@ -1,7 +1,7 @@
 # Technical hotfixes not belonging to any specific livecd feature/requirement 
-{ configs, lib, boot, ... }:
+{ config, lib, boot, ... }:
 {
     # Fixes missing cairo-lib dependency for docker builds only
     # See https://github.com/NixOS/nixpkgs/issues/119841
-    environment.noXlibs = lib.mkIf boot.isContainer (lib.mkForce false);
+    environment.noXlibs = lib.mkIf config.boot.isContainer (lib.mkForce false);
 }

--- a/modules/patches.nix
+++ b/modules/patches.nix
@@ -1,5 +1,5 @@
 # Technical hotfixes not belonging to any specific livecd feature/requirement 
-{ lib, boot, ... }:
+{ configs, lib, boot, ... }:
 {
     # Fixes missing cairo-lib dependency for docker builds only
     # See https://github.com/NixOS/nixpkgs/issues/119841

--- a/modules/patches.nix
+++ b/modules/patches.nix
@@ -1,5 +1,5 @@
 # Technical hotfixes not belonging to any specific livecd feature/requirement 
-{ lib, ... }:
+{ lib, boot, ... }:
 {
     # Fixes missing cairo-lib dependency for docker builds only
     # See https://github.com/NixOS/nixpkgs/issues/119841


### PR DESCRIPTION
## Description

Fixes docker build by forcing xLib to not being disabled. Introduces a file specifically dedicated to hotfixing certain bugs that aren't product specific but is needed for build reasons, etc.

Fixes #26.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

