### PR TITLE
style: Move display manager lightdm section in gnome.nix to lightdm.nix

### DIFF
--- a/modules/Desktop Environment/gnome.nix
+++ b/modules/Desktop Environment/gnome.nix
@@ -13,16 +13,8 @@
 
   services.xserver = {
     enable = true;
-
-    displayManager.lightdm = {
-      enable = true;
-      greeters.gtk.enable = true;  
-      autoLogin.enable = true;
-      autoLogin.user = "nixos-livecd";
-    };
-    
     displayManager.defaultSession = "gnome";
-    desktopManager.gnome.enable = true; 
+    desktopManager.gnome.enable = true;
   };
 
   services.gnome = {

--- a/modules/Display Manager/lightdm.nix
+++ b/modules/Display Manager/lightdm.nix
@@ -1,0 +1,8 @@
+{
+  services.xserver.displayManager.lightdm = {
+    enable = true;
+    greeters.gtk.enable = true;
+    autoLogin.enable = true;
+    autoLogin.user = "nixos-livecd";
+  };
+}


### PR DESCRIPTION
## Description

Realized that the lightdm display manager should go to the "display manager" folder


## Type of change

Please delete options that are not relevant.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

None required this is just moving code from one file to another
