### PR TITLE
build: Switch maximize build space action repo to own(cnshing) fork repo

### DIFF
--- a/.github/workflows/build-livecd.yml
+++ b/.github/workflows/build-livecd.yml
@@ -83,11 +83,13 @@ jobs:
       # Frees available build disk space by removing unnecessary components
       # Hacky workaround can break at any time dependent on Github's current VM runner configuration
       - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v1
+        uses: cnshing/remove-unwanted-software-feature-codeql-docker-support@master
         if: inputs.format == 'virtualbox'
         with:
           remove-android: 'true'
           remove-dotnet: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

The virtualbox builds are failing again, so I decided to create my own fork since the original fork were not updated to the latest action. This created an additional 9GBs of space with the new configuration.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

